### PR TITLE
Fixed alpha gradient bug

### DIFF
--- a/src/main/java/com/larvalabs/svgandroid/SVGParser.java
+++ b/src/main/java/com/larvalabs/svgandroid/SVGParser.java
@@ -1325,7 +1325,8 @@ public class SVGParser {
 					} else {
 						float alpha = props.getFloat("stop-opacity", 1) * currentLayerAttributes().opacity;
 						int alphaInt = Math.round(255 * alpha);
-						colour = stopColour.intValue() | (alphaInt << 24);
+						// wipe the auto FF opacity from getColor() before applying stop-opacity:
+						colour = (stopColour.intValue() & 0xFFFFFF) | (alphaInt << 24);
 					}
 					gradient.colors.add(colour);
 


### PR DESCRIPTION
Fixed bug that prevented gradients with varying alpha from being displayed properly.

Commit d1f6374 unintentionally broke gradient fills that change in opacity because the call to Color.parseColor () implicitly set the alpha value of the colour to FF. The stop-opacity is applied with a bitwise OR, so the FF would overrule the 'true' value.
